### PR TITLE
fix: hydration errors

### DIFF
--- a/src/components/buttons/like-button.tsx
+++ b/src/components/buttons/like-button.tsx
@@ -1,0 +1,21 @@
+import LikeIcon from "../icons/like-icon";
+import { Offer } from "../../content/content";
+import { useFavoritesStore } from "../../store/favorites-store";
+import { useIsFavorite } from "../../hooks/use-is-favorite";
+
+export function LikeButton({ offer }: { offer: Offer }) {
+	const { toggleFavorite } = useFavoritesStore();
+	const isFavorite = useIsFavorite(offer);
+
+	return (
+		<button
+			onClick={(e) => {
+				e.stopPropagation();
+				e.preventDefault();
+				toggleFavorite(offer);
+			}}
+		>
+			<LikeIcon isSelected={isFavorite}></LikeIcon>
+		</button>
+	);
+}

--- a/src/components/offer/offer-detail.tsx
+++ b/src/components/offer/offer-detail.tsx
@@ -1,20 +1,15 @@
 import React, { useMemo } from "react";
 import { Offer } from "../../content/content";
-import { useFavoritesStore } from "../../store/favorites-store";
 import ArrowRightIcon from "../icons/arrow-right-icon";
-import LikeIcon from "../icons/like-icon";
 import { Pill } from "./pill";
 import { allowedOfferPathsWithImagesAllowed } from "../../content/allowed-offers-images";
+import { LikeButton } from "../buttons/like-button.tsx";
 
 interface OfferDetailProps {
 	offer: Offer;
 }
 
 const OfferDetail: React.FC<OfferDetailProps> = ({ offer }) => {
-	const [isFavorite, addFavorite, removeFavorite] = useFavoritesStore(
-		(state) => [state.isFavorite, state.addFavorite, state.removeFavorite],
-	);
-
 	const MAGIC_CUTOFF_LIMIT = 165;
 
 	const cutoffDescription = useMemo(() => {
@@ -65,19 +60,7 @@ const OfferDetail: React.FC<OfferDetailProps> = ({ offer }) => {
 					</div>
 				</div>
 				<div className="min-w-[43px] flex justify-center">
-					<button
-						onClick={(e) => {
-							e.stopPropagation();
-							e.preventDefault();
-							if (isFavorite(offer)) {
-								removeFavorite(offer);
-							} else {
-								addFavorite(offer);
-							}
-						}}
-					>
-						<LikeIcon isSelected={isFavorite(offer)}></LikeIcon>
-					</button>
+					<LikeButton offer={offer} />
 				</div>
 			</div>
 			<div className="border-b border-berlin-grey-light w-full"></div>

--- a/src/components/offer/offer-full.tsx
+++ b/src/components/offer/offer-full.tsx
@@ -1,28 +1,23 @@
 import React, { useState } from "react";
 import { Offer } from "../../content/content";
-import { useFavoritesStore } from "../../store/favorites-store";
 import ShareButton from "../buttons/share-button";
-import LikeIcon from "../icons/like-icon";
 import LinkIcon from "../icons/link-icon";
 import { Pill } from "./pill";
 import RouteButton from "../buttons/route-button";
 import { allowedOfferPathsWithImagesAllowed } from "../../content/allowed-offers-images";
+import { LikeButton } from "../buttons/like-button.tsx";
 
 interface OfferFullProps {
 	offer: Offer;
 }
 
 const OfferFull: React.FC<OfferFullProps> = ({ offer }) => {
-	const [addFavorite, removeFavorite, isFavorite] = useFavoritesStore(
-		(state) => [state.addFavorite, state.removeFavorite, state.isFavorite],
-	);
-
 	const [showFullDescription, setShowFullDescription] = useState(false);
 
 	return (
 		<div className="w-full">
 			<div className="flex flex-row gap-2 w-full justify-end pr-4 pb-4 sm:hidden">
-				<LikeIcon isSelected={false} />
+				<LikeButton offer={offer} />
 				<ShareButton offer={offer} />
 			</div>
 			<div className="flex flex-row pb-2 slg0 gap-4">
@@ -72,17 +67,7 @@ const OfferFull: React.FC<OfferFullProps> = ({ offer }) => {
 					</a>
 				</div>
 				<div className="hidden max-w-[20%] w-full sm:flex flex-row justify-center items-start gap-2">
-					<button
-						onClick={() => {
-							if (isFavorite(offer)) {
-								removeFavorite(offer);
-							} else {
-								addFavorite(offer);
-							}
-						}}
-					>
-						<LikeIcon isSelected={isFavorite(offer)}></LikeIcon>
-					</button>
+					<LikeButton offer={offer} />
 					<ShareButton offer={offer} />
 				</div>
 			</div>

--- a/src/components/offer/offer-popup.tsx
+++ b/src/components/offer/offer-popup.tsx
@@ -1,19 +1,14 @@
 import React, { useMemo } from "react";
 import { Offer } from "../../content/content";
-import { useFavoritesStore } from "../../store/favorites-store";
 import ArrowRightIcon from "../icons/arrow-right-icon";
-import LikeIcon from "../icons/like-icon";
 import { Pill } from "./pill";
+import { LikeButton } from "../buttons/like-button";
 
 interface OfferPopupProps {
 	offer: Offer;
 }
 
 const OfferPopup: React.FC<OfferPopupProps> = ({ offer }) => {
-	const [isFavorite, addFavorite, removeFavorite] = useFavoritesStore(
-		(state) => [state.isFavorite, state.addFavorite, state.removeFavorite],
-	);
-
 	const MAGIC_CUTOFF_LIMIT = 80;
 
 	const cutoffDescription = useMemo(() => {
@@ -40,7 +35,7 @@ const OfferPopup: React.FC<OfferPopupProps> = ({ offer }) => {
 							<Pill title={"Freier Eintritt"} />
 						</div>
 					)}
-					<div className={`break-words text-left cusor-default`}>
+					<div className={`break-words text-left cursor-default`}>
 						{cutoffDescription}
 					</div>
 					<div className="flex flex-row w-full justify-end text-primary-blue">
@@ -51,19 +46,7 @@ const OfferPopup: React.FC<OfferPopupProps> = ({ offer }) => {
 					</div>
 				</div>
 				<div className="min-w-[43px] flex justify-center">
-					<button
-						onClick={(e) => {
-							e.stopPropagation();
-							e.preventDefault();
-							if (isFavorite(offer)) {
-								removeFavorite(offer);
-							} else {
-								addFavorite(offer);
-							}
-						}}
-					>
-						<LikeIcon isSelected={isFavorite(offer)}></LikeIcon>
-					</button>
+					<LikeButton offer={offer} />
 				</div>
 			</div>
 		</div>

--- a/src/hooks/use-is-favorite.tsx
+++ b/src/hooks/use-is-favorite.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+import { Offer } from "../content/content";
+import { useFavoritesStore } from "../store/favorites-store";
+
+export function useIsFavorite(offer: Offer) {
+	const { favorites, isFavorite: isFavoriteInLocalStorage } =
+		useFavoritesStore();
+	const [isFavorite, setIsFavorite] = useState(false);
+
+	useEffect(() => {
+		if (isFavoriteInLocalStorage(offer)) {
+			setIsFavorite(true);
+			return;
+		}
+
+		setIsFavorite(false);
+	}, [offer, favorites]);
+
+	return isFavorite;
+}

--- a/src/store/favorites-store.ts
+++ b/src/store/favorites-store.ts
@@ -6,6 +6,7 @@ interface FavoritesState {
 	favorites: string[];
 	addFavorite: (offer: Offer) => void;
 	removeFavorite: (offer: Offer) => void;
+	toggleFavorite: (offer: Offer) => void;
 	isFavorite: (offer: Offer) => boolean;
 	getKey: (offer: Offer) => string;
 }
@@ -14,24 +15,36 @@ export const useFavoritesStore = create<FavoritesState>()(
 	persist(
 		(set, get) => ({
 			favorites: [],
+
 			addFavorite: (offer) =>
 				set((state) => ({
 					favorites: state.favorites.includes(get().getKey(offer))
 						? state.favorites
 						: [...state.favorites, get().getKey(offer)],
 				})),
+
 			removeFavorite: (offer) =>
 				set((state) => ({
 					favorites: state.favorites.filter(
 						(item) => item !== get().getKey(offer),
 					),
 				})),
+
+			toggleFavorite: (offer) => {
+				if (get().isFavorite(offer)) {
+					get().removeFavorite(offer);
+					return;
+				}
+
+				get().addFavorite(offer);
+			},
+
 			isFavorite: (offer) => get().favorites.includes(get().getKey(offer)),
+
 			getKey: (offer) => offer.path.split("/").slice(-2)[0],
 		}),
 		{
 			name: "favorites-storage",
-			getStorage: () => localStorage,
 		},
 	),
 );


### PR DESCRIPTION
When the browser hydrates the app, the like button reads directly from the local storage, which results in hydration errors: the html generated on build time (no like) can be different than what is rendered in the browser (like). To fix this, we need to start with a no-like state and update the state in an effect. 

edit: also fixed a bug where the like button would stay outlined grey and not filled red when liked on a detail page on mobile