### PR TITLE
fix: navigation in filter on show offers button

### DIFF
--- a/src/components/menu/filter-menu.tsx
+++ b/src/components/menu/filter-menu.tsx
@@ -120,10 +120,7 @@ const FilterMenu: React.FC<FilterMenuProps> = ({ isOpen, close }) => {
 				};
 			}),
 		);
-		if (window.location.pathname === "/") {
-			navigate("/all-offers/?free=false" + searchParams);
-			return;
-		}
+		navigate(`${window.location.pathname}?free=false&${searchParams}`);
 		close();
 	};
 
@@ -136,7 +133,10 @@ const FilterMenu: React.FC<FilterMenuProps> = ({ isOpen, close }) => {
 				};
 			}),
 		);
-		if (!window.location.pathname.includes("/all-offers/")) {
+		/**
+		 * If we are on the home page, we navigate to the all-offers page
+		 */
+		if (["/", "/en/"].includes(window.location.pathname)) {
 			const languagePrefix = language === "de" ? "" : `/${language}`;
 			navigate(`${languagePrefix}/all-offers/?${searchParams.toString()}`);
 			return;


### PR DESCRIPTION
a bug I discovered: if you are on the `/map` page and you want to filter some offers, when you click on the `show offers` button in the filter drawer, you get redirected to the `all-offers` page. 